### PR TITLE
Add JWT authentication with login endpoint

### DIFF
--- a/WebApplication1/AuthController.cs
+++ b/WebApplication1/AuthController.cs
@@ -1,0 +1,43 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using BookApi.Models;
+
+namespace BookApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly IConfiguration _configuration;
+    private readonly List<User> _users = new()
+    {
+        new User { Username = "test", Password = "password" }
+    };
+
+    public AuthController(IConfiguration configuration) => _configuration = configuration;
+
+    [AllowAnonymous]
+    [HttpPost("login")]
+    public IActionResult Login([FromBody] User login)
+    {
+        var user = _users.SingleOrDefault(u => u.Username == login.Username && u.Password == login.Password);
+        if (user == null)
+            return Unauthorized();
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!);
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, user.Username) }),
+            Expires = DateTime.UtcNow.AddHours(1),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256)
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return Ok(new { token = tokenHandler.WriteToken(token) });
+    }
+}

--- a/WebApplication1/BooksController.cs
+++ b/WebApplication1/BooksController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using BookApi.Data;
@@ -7,6 +8,7 @@ namespace BookApi.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class BooksController : ControllerBase
     {
         private readonly BooksContext _context;

--- a/WebApplication1/Models/User.cs
+++ b/WebApplication1/Models/User.cs
@@ -1,0 +1,7 @@
+namespace BookApi.Models;
+
+public class User
+{
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/WebApplication1/Program.cs
+++ b/WebApplication1/Program.cs
@@ -1,0 +1,39 @@
+using System.Text;
+using BookApi.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddDbContext<BooksContext>(opt => opt.UseInMemoryDatabase("Books"));
+
+var key = builder.Configuration["Jwt:Key"] ?? "ThisIsASuperSecretKeyForJwt1234567890";
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = false,
+        ValidateAudience = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+    };
+});
+
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/WebApplication1/WebApplication1.csproj
+++ b/WebApplication1/WebApplication1.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/WebApplication1/appsettings.json
+++ b/WebApplication1/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Jwt": {
+    "Key": "ThisIsASuperSecretKeyForJwt1234567890"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- install JWT bearer and EF Core InMemory packages
- add simple user model and login controller issuing JWTs
- configure authentication/authorization and protect books API

## Testing
- `dotnet build WebApplication1/WebApplication1.csproj`
- `curl -i http://localhost:5000/api/books` (401)
- `curl -s -i http://localhost:5000/api/auth/login -H "Content-Type: application/json" -d '{"username":"test","password":"password"}'`
- `curl -i http://localhost:5000/api/books -H "Authorization: Bearer $TOKEN"`


------
https://chatgpt.com/codex/tasks/task_e_689333de324483319179dc0ed07f81b4